### PR TITLE
Dev py38 support

### DIFF
--- a/django_event_observer/apps.py
+++ b/django_event_observer/apps.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+import typing
+
 from django.apps import AppConfig
 from django.conf import settings
 from django.utils.module_loading import import_string
@@ -8,7 +12,7 @@ from .observers.abstract import BaseAbstractObserver
 
 
 class DjangoEventObserverConfig(AppConfig):
-    _event_manager: EventManager | None = None
+    _event_manager: typing.Optional[EventManager] = None  # noqa: UP007
     default_auto_field = "django.db.models.BigAutoField"
     name = "django_event_observer"
 

--- a/django_event_observer/apps.py
+++ b/django_event_observer/apps.py
@@ -26,12 +26,13 @@ class DjangoEventObserverConfig(AppConfig):
             raise ValueError(msg)
         return self._event_manager
 
-    def load_event_manager(self) -> EventManager:
+    def load_event_manager(self):
         event_manager_class = import_string(self.app_settings["EVENT_MANAGER"])
         if not issubclass(event_manager_class, EventManager):
             msg = f"{event_manager_class} is not a subclass of EventManager"
             raise TypeError(msg)
-        return event_manager_class()
+        if self._event_manager is None:
+            self._event_manager = event_manager_class()  # noqa: WPS601
 
     def ready(self):
         self.load_event_manager()

--- a/django_event_observer/event_manager.py
+++ b/django_event_observer/event_manager.py
@@ -1,13 +1,17 @@
+from __future__ import annotations
+
+
 __all__ = ("EventManager",)
+
 
 from collections import defaultdict
 import typing
 
-from .events.base import BaseEvent
+from .events.base import BaseEvent  # noqa: TCH001
 from .observers.abstract import BaseAbstractObserver
 
 
-_ObserversT = dict[str, list[BaseAbstractObserver]]
+_ObserversT = typing.Dict[str, typing.List[BaseAbstractObserver]]  # noqa: UP006
 
 
 class EventManager:

--- a/django_event_observer/events/base.py
+++ b/django_event_observer/events/base.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 __all__ = ("BaseEvent",)
 
 import typing

--- a/django_event_observer/events/models/model_event_enums.py
+++ b/django_event_observer/events/models/model_event_enums.py
@@ -1,5 +1,14 @@
 __all__ = ("ModelSignalEventEnum",)
-from enum import StrEnum
+
+# flake8: noqa
+
+try:
+    from enum import StrEnum
+except ImportError:
+    from enum import Enum
+
+    class StrEnum(str, Enum):  # type: ignore
+        pass
 
 
 class ModelSignalEventEnum(StrEnum):

--- a/django_event_observer/events/models/signal_event.py
+++ b/django_event_observer/events/models/signal_event.py
@@ -1,9 +1,12 @@
+from __future__ import annotations
+
+
 __all__ = ("BaseModelSignalEvent",)
 
 from django.db import models
 
 from ..base import BaseEvent
-from .model_event_enums import ModelSignalEventEnum
+from .model_event_enums import ModelSignalEventEnum  # noqa: TCH001
 
 
 class BaseModelSignalEvent(BaseEvent[models.Model]):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ requires = ["setuptools", "wheel"]
 
 [project]
 name = "django_event_observer"
-version = "2024.1.1"
-requires-python = "~=3.13"
+version = "2024.11.2"
+requires-python = ">=3.8"
 description = ""
 readme = "README.md"
 dependencies = ["django>=4.1", ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["setuptools", "wheel"]
 
 [project]
 name = "django_event_observer"
-version = "2024.1.0"
+version = "2024.1.1"
 requires-python = "~=3.13"
 description = ""
 readme = "README.md"


### PR DESCRIPTION
Temporary support for Python 3.8 has been added.

Further development will continue exclusively in the context of Python 3.11+.